### PR TITLE
Add link to pkgdown website

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -76,5 +76,5 @@ Imports:
     english,
     waldo,
     stringr
-URL: https://github.com/idem-lab/conmat
+URL: https://idem-lab.github.io/conmat/, https://github.com/idem-lab/conmat
 BugReports: https://github.com/idem-lab/conmat/issues

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,3 +1,4 @@
+url: https://idem-lab.github.io/conmat
 
 home:
   title: An R Package For Creating Synthetic Contact Matrices


### PR DESCRIPTION
To enable cross-linking from other pkgdown websites. See https://pkgdown.r-lib.org/articles/linking.html#across-packages

Related to https://github.com/openjournals/joss-reviews/issues/8326